### PR TITLE
Fix 13 reaches with inconsistent main_side=0 (#108)

### DIFF
--- a/.claude/napkin.md
+++ b/.claude/napkin.md
@@ -1,0 +1,45 @@
+# Napkin
+
+## Corrections
+| Date | Source | What Went Wrong | What To Do Instead |
+|------|--------|----------------|-------------------|
+| 2026-02-15 | self | ogr2ogr GPKG doesn't have `name:en` as column — it's in `other_tags` hstore | Always check GPKG column schema before assuming column existence; use `regexp_extract(other_tags, ...)` for extended OSM tags |
+| 2026-02-15 | self | `river_name = 'NODATA'` not NULL — sentinel string | SWORD uses `'NODATA'` string, not NULL, for missing `river_name` values |
+| 2026-02-15 | self | DuckDB `ALTER TABLE RENAME COLUMN` fails when views depend on table | Drop dependent views/indexes first, rename, then recreate |
+| 2026-02-15 | self | Deployed DuckDB on GCS only has `reaches` table, no `nodes` | Use `reaches.geom` LINESTRING as fallback for geometry; parse WKT with `ST_AsText` |
+| 2026-02-15 | self | SWORD LINESTRING geom runs downstream-to-upstream, not upstream-to-downstream | Reverse coords after parsing WKT; nodes `ORDER BY dist_out DESC` gives upstream-to-downstream |
+| 2026-02-15 | self | C004 valid combos had lakeflag=1+type=3 as valid (lake+tidal_river) | **WRONG** — this "correction" was itself wrong and caused 22k false positives. See 2026-02-16 entry. |
+| 2026-02-16 | self | Previous session changed lakeflag=1 valid types from (3,4) to (2,4), thinking type=3 was "tidal_river". type=3 is actually "lake_on_river" per PDD. Caused 22,580 false mismatches. type=2 doesn't even exist in SWORD data. | **SWORD type field**: 1=river, 3=lake_on_river, 4=dam, 5=unreliable, 6=ghost. NO type=2. Tidal is lakeflag=3, NOT type=3. Always check validation spec before changing valid combos. |
+| 2026-02-15 | self | Substring match `"lake" in issue_type` caught "river_labeled_as_lake_type" | Use exact `==` match on issue_type strings, never substring match for dispatch |
+
+## User Preferences
+- Prefers concise plans, sacrifice grammar for brevity
+- No speculative features
+- `uv` not pip, `ruff` not black/pylint, `pytest -q`
+- Never push to main — feature branches + PRs to gearon_dev3
+- Use SCRATCHPAD.md for working memory, HANDOVER.md for session summaries
+
+| 2026-02-16 | self (audit) | C004 fixes were logged via `log_skip()` — recorded as action='skip' with NULL old/new values, making them untrackable and un-undoable | Use `apply_column_fix()` which reads old value, does UPDATE, and logs with action='fix', column_changed, old_value, new_value |
+| 2026-02-16 | self (audit) | Dead code after `st.rerun()` in C004 tab — nested button block could never execute | Code after `st.rerun()` is unreachable; delete it |
+| 2026-02-16 | self (audit) | `undo_last_fix` hardcoded `lakeflag` column regardless of what `column_changed` was | Read `column_changed` from fix log and use it dynamically in the undo UPDATE |
+| 2026-02-16 | user report | Refreshing deployed app lost all review progress — Cloud Run copies fresh DuckDB from GCS on each instance start, lint_fix_log and data fixes in /tmp are ephemeral | JSON session files on GCS persist; added `replay_persisted_fixes()` at startup to re-apply fixes and restore lint_fix_log from JSON |
+
+## Patterns That Work
+- RTREE drop/recreate pattern for DuckDB UPDATEs on spatial tables
+- Parallel background agents for independent region processing
+- Check `ST_Read(...) LIMIT 0` description to detect column availability
+- Skills need `SKILL.md` inside a directory (`.claude/skills/name/SKILL.md`), not flat `.md` files, for proper frontmatter discovery
+- `workflow.export()` is broken — `_do_export` passes `self._sword.db` (connection) not `self._sword` (SWORD instance). Call export functions directly.
+
+## Domain Notes
+- **SWORD `type` field**: 1=river, 3=lake_on_river, 4=dam, 5=unreliable, 6=ghost. **Type=2 does NOT exist.** Type=3 is NOT tidal — tidal is lakeflag=3.
+- **lakeflag=1 + type=3** is the PRIMARY expected lake combo (21k+ reaches). Do NOT flag it as mismatch.
+- SWORD name columns: `river_name` (GRWL), `river_name_en` (standardized English), `river_name_local` (OSM local name)
+- 248,674 total reaches; 55,671 still completely unnamed after OSM enrichment
+- OSM `name:en` coverage is sparse — only 69K reaches have real English translations
+- OC is worst region for OSM coverage (Papua/Pacific Islands barely mapped)
+- v17b is READ-ONLY reference; all edits go to v17c
+- Region views (`af_reaches`, `na_reaches`, etc.) use `SELECT *` — must drop/recreate when renaming columns
+- **42215900111** (labeled "Amur", w=1016): NOT mainstem — it's a tributary with wrong facc (11.8M, Amur-scale). Candidate for facc fix (#14).
+- **main_side=0 + stream_order=-9999**: remaining 27 are correct main_side=0 but path_freq was never computed → #16 scope, not main_side bug
+- Tributary mainstem → larger river confluence (e.g. Munneru→Krishna): already handled by rch_id_up/dn_main routing. Leave main_side=0.


### PR DESCRIPTION
## Summary
- Set `main_side=1` for 13 AS reaches that had `main_side=0` but `stream_order=-9999` and `path_freq=0`
- Both v17b path traversal and v17c Dijkstra agree these are not mainstem
- Fix applied directly to `sword_v17c.duckdb` (gitignored); commit tracks napkin notes

## Reaches fixed (main_side 0→1)

**9 clear-cut** (both neighbors also main_side=1):
31221000901, 31221001456, 31241900451, 31252700156, 31252700173 (Konda), 34219100061, 43495603954 (Puyang), 44106002623, 45660100244

**4 manually reviewed:**
- 42215900111 ("Amur" label, w=1016) — tributary, not mainstem. Also has wrong facc (#14 candidate)
- 43428600471 (Ruhe, w=14) — not mainstem
- 31350000201 (NODATA, w=42) — not mainstem
- 45311901975 (NODATA, w=2040, type=5 unreliable, lakeflag=3 tidal) — not mainstem

## Remaining 25 (correctly main_side=0)
23 Kundu River + 43421001561 (junction) + 45361000901 (Munneru→Krishna confluence). Their issue is missing `path_freq`/`stream_order` — #16 scope.

## Test plan
- [x] Verified before/after values for all 13 reaches
- [x] Confirmed remaining 25 are correctly main_side=0 via neighbor analysis and routing check
- [x] RTREE indexes dropped before UPDATE and recreated after

Closes #108