### PR TITLE
Fix has_extreme bitmask in flow direction scoring

### DIFF
--- a/src/updates/sword_v17c_pipeline/flow_direction.py
+++ b/src/updates/sword_v17c_pipeline/flow_direction.py
@@ -94,7 +94,7 @@ def _get_reach_quality(reach_ids: List[int], reaches_df: pd.DataFrame) -> Dict:
     n_good = sum(1 for q in slope_q_vals if q == 0)
     frac_good = n_good / len(slope_q_vals) if slope_q_vals else 0
     med_passes = float(np.median(n_passes_vals)) if n_passes_vals else 0
-    has_extreme = any(q & (4 | 8) for q in slope_q_vals)
+    has_extreme = any(q & 8 for q in slope_q_vals)
     has_lake = False
     if "lakeflag" in avail:
         lf_vals = subset["lakeflag"].dropna()


### PR DESCRIPTION
## Summary

- `has_extreme` in `_get_reach_quality()` used `q & (4 | 8)` which catches bit 2 (high variability). Bit 2 is common in low-gradient rivers (61k reaches have `slope_obs_q=20` = bits 2+4). Only bit 3 (value 8, extreme slope >50 m/km) should disqualify a section from auto-flip.
- Changed to `q & 8`
- Added regression test confirming high-variability flag does not block flips

## Test plan

- [x] All 17 flow direction tests pass
- [x] New test `test_high_variability_does_not_block` verifies bit 2 alone → HIGH tier
- [x] Existing `test_low_confidence_extreme_flags` still catches bit 3 → LOW tier