### PR TITLE
Fix lint check bugs, severities, and remove redundant checks

### DIFF
--- a/.claude/napkin.md
+++ b/.claude/napkin.md
@@ -36,6 +36,10 @@
 | 2026-02-19 | self (review) | `conn.register("name", df)` without try/finally leaks on exception — subsequent calls get "Table already exists" | Always wrap `conn.register` / `conn.unregister` in try/finally |
 | 2026-02-19 | self (review) | DuckDB gate opening read-only LintRunner while write connection is active causes stale reads | Call `conn.execute("CHECKPOINT")` before opening a second connection to the same DB |
 
+| 2026-02-20 | code review | N006 boundary_dist_out used MAX(node_id) for upstream reach's downstream boundary and MIN(node_id) for downstream reach's upstream boundary — backwards given SWORD convention (node_id increases upstream) | Upstream reach's downstream boundary = MIN(node_id); downstream reach's upstream boundary = MAX(node_id). Keep threshold at 1000m. |
+| 2026-02-20 | code review | N010 node_index_contiguity used `max - min + 1` formula assuming step-1 suffixes, but SWORD uses step-10 (001, 011, 021, ..., 991) | Use `(max - min) / 10 + 1` for expected count |
+| 2026-02-20 | user decision | N006 threshold discussed — 1000m kept as-is per user preference | Do not change N006 threshold from 1000m |
+
 ## Patterns That Work
 - RTREE drop/recreate pattern for DuckDB UPDATEs on spatial tables
 - Parallel background agents for independent region processing


### PR DESCRIPTION
## Summary
- Remove T016 (centroid distance) and N007 (boundary geolocation) — redundant with existing G012 (endpoint alignment)
- Fix N004 direction: SWORD convention is node_id increases upstream (dist_out increases with node_id). Old check flagged 89% of reaches; fixed check finds 0 violations.
- Fix N006 boundary node selection: swap MIN/MAX to compare correct junction endpoints after N004 convention fix
- Fix N010 step-10 formula: SWORD uses step-10 node suffixes (001, 011, 021...), not step-1. Old formula produced 10K false positives; fixed formula finds 0 issues.
- Severity changes: N004 ERROR→WARNING, T020 WARNING→INFO, N010 WARNING→INFO
- All test data aligned to SWORD node_id convention (dist_out increasing with node_id)

## Validated against full DB (all 6 regions, 248K reaches, 11.1M nodes)

| Check | Before | After |
|-------|--------|-------|
| N004 | 89% false violations | 0 issues |
| N006 | ~10K (wrong ends) | 2,598 real issues (1.05%) |
| N010 | 10K false positives | 0 issues |
| T016 | removed (redundant with G012) | — |
| N007 | removed (redundant with G012) | — |

## Test plan
- [x] 97 lint tests pass
- [x] All checks validated against production DB
- [x] Agent code review (2 rounds — caught N006 bug on first round)