### PR TITLE
Fix dist_out monotonicity at bifurcations (#12)

### DIFF
--- a/src/sword_duckdb/lint/checks/topology.py
+++ b/src/sword_duckdb/lint/checks/topology.py
@@ -1194,8 +1194,10 @@ def check_dist_out_bifurcation_monotonicity(
     total_query = f"""
     SELECT COUNT(*) FROM reaches r1
     JOIN reach_topology rt ON r1.reach_id = rt.reach_id AND r1.region = rt.region
+    JOIN reaches r2 ON rt.neighbor_reach_id = r2.reach_id AND rt.region = r2.region
     WHERE rt.direction = 'down'
         AND r1.dist_out > 0 AND r1.dist_out != -9999
+        AND r2.dist_out > 0 AND r2.dist_out != -9999
         {where_clause}
     """
     total = conn.execute(total_query).fetchone()[0]


### PR DESCRIPTION
## Summary
- Add `scripts/topology/fix_dist_out_bifurcations.py` to correct 243 bifurcation reaches where dist_out was computed with MIN instead of MAX of downstream neighbors (a v17b bug in UNC's retry mechanism)
- BFS cascades upstream to recompute ~71K affected reaches; node dist_out updated via delta shift
- Add T021 `dist_out_bifurcation_monotonicity` lint check (WARNING) for per-edge monotonicity at bifurcations

## Test plan
- [ ] Run `python scripts/topology/fix_dist_out_bifurcations.py --db data/duckdb/sword_v17c.duckdb --dry-run` to preview changes
- [ ] Run without `--dry-run` to apply; script self-verifies 0 remaining violations
- [ ] Run T001 and T021 lint checks post-fix to confirm both pass
- [ ] `pytest -q -k "dist_out or lint or topology"` passes