### PR TITLE
Align PostgreSQL schema with DuckDB v17c

### DIFF
--- a/scripts/maintenance/load_from_duckdb.py
+++ b/scripts/maintenance/load_from_duckdb.py
@@ -582,6 +582,8 @@ Examples:
         "sword_snapshots",
         "v17c_sections",
         "v17c_section_slope_validation",
+        "facc_corrections",
+        "v17c_flow_corrections",
         "facc_fix_log",
         "lint_fix_log",
         "imagery_acquisitions",


### PR DESCRIPTION
## Summary
- Replace stale mean/median/std SWOT obs columns with percentile-based (p10-p90, mad) in nodes and reaches
- Add missing columns: `node_order`, `dn_node_id`, `up_node_id`, `river_name_local`, `river_name_en`, `topology_suspect`, `topology_approved`
- Add missing tables: `facc_corrections`, `v17c_flow_corrections`
- Fix `facc_fix_log` schema (SERIAL PK → INTEGER, add `batch_id`/`model_used`/`facc_corrected`)
- Add `facc_corrections` and `v17c_flow_corrections` to loader default table list
- Bump schema version to 1.7.0

## Test plan
- [x] Full reload of all 6 regions completed (80.2M rows, ~72 min)
- [x] v17b geometry overwrite applied (248,673 reaches)
- [x] Verified all new columns populated (dn_node_id, node_order, percentiles, topology flags)
- [x] Verified per-region row counts match across all tables