### PR TITLE
Ignore .playwright-mcp/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,7 @@ models/
 HANDOVER.md
 SCRATCHPAD.md
 .worktrees/
+.playwright-mcp/
 
 # Output artifacts
 output/


### PR DESCRIPTION
## Summary

Adds `.playwright-mcp/` to `.gitignore`. This directory is created as scratch space by the Playwright MCP server during browser-automation sessions. It is tool output, not source, and should never be committed.

## Change

One line added to `.gitignore`, grouped with the existing session-file ignores (`HANDOVER.md`, `SCRATCHPAD.md`, `.worktrees/`).